### PR TITLE
Use Extended DDP Packets for NBP Lookup Requests On LocalTalk

### DIFF
--- a/tashrouter/port/localtalk/__init__.py
+++ b/tashrouter/port/localtalk/__init__.py
@@ -166,7 +166,7 @@ class LocalTalkPort(Port):
   def multicast(self, zone_name, datagram):
     if self.node == 0: return
     log_datagram_multicast(zone_name, datagram, self)
-    self.send_frame(bytes((0xFF, self.node, self.LLAP_APPLETALK_SHORT_HEADER)) + datagram.as_short_header_bytes())
+    self.send_frame(bytes((0xFF, self.node, self.LLAP_APPLETALK_LONG_HEADER)) + datagram.as_long_header_bytes())
   
   def _set_network(self, network):
     logging.info('%s assigned network number %d', str(self), network)


### PR DESCRIPTION
When broadcasting NBP multicast packets on a non-extended network (LocalTalk), use the network's number in broadcasts. When it is an extended network (EtherTalk), use "0". This mirrors the behavior of commercial AppleTalk routers such as the Shiva Fastpath.

It also avoids annoying behavior with the ImageWriter LocalTalk Option card. That card will unconditionally send back NBP responses to the initial requestor's address (in this case, TashRouter) if using short DDP packets for lookups, not the destination in the NBP tuple.